### PR TITLE
use language: julia on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 notifications:
   email: false
 julia:
-  - 0.3
   - 0.4
   - nightly
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
-language: cpp
-compiler:
-  - clang
+language: julia
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+julia:
+  - 0.3
+  - 0.4
+  - nightly
 script:
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("AbstractDomains")'


### PR DESCRIPTION
~~allows testing against 0.3, which REQUIRE still indicates is supported~~

usually the generic nightlies used by `language: julia` are more up to date than the julianightlies ppa
